### PR TITLE
Change pyjq to jq

### DIFF
--- a/g2p_openid_vci/__manifest__.py
+++ b/g2p_openid_vci/__manifest__.py
@@ -12,7 +12,7 @@
         "g2p_registry_base",
         "g2p_encryption",
     ],
-    "external_dependencies": {"python": ["cryptography<37", "python-jose", "pyjq", "PyLD"]},
+    "external_dependencies": {"python": ["cryptography<37", "python-jose", "jq", "PyLD"]},
     "data": [
         "security/ir.model.access.csv",
         "views/vci_issuers.xml",

--- a/g2p_openid_vci/models/vci_issuer.py
+++ b/g2p_openid_vci/models/vci_issuer.py
@@ -4,7 +4,7 @@ import os
 import uuid
 from datetime import datetime
 
-import pyjq as jq
+import jq
 import requests
 from cryptography.hazmat.primitives import hashes
 from jose import jwt

--- a/g2p_openid_vci_rest_api/__manifest__.py
+++ b/g2p_openid_vci_rest_api/__manifest__.py
@@ -12,7 +12,7 @@
         "fastapi",
         "extendable_fastapi",
     ],
-    "external_dependencies": {"python": ["extendable-pydantic", "pydantic", "pyjq"]},
+    "external_dependencies": {"python": ["extendable-pydantic", "pydantic", "jq"]},
     "data": ["data/fastapi_endpoint_vci.xml"],
     "assets": {
         "web.assets_backend": [],

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@
 PyLD
 cryptography<37
 extendable-pydantic
-pydantic
 jq
+pydantic
 python-jose

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ PyLD
 cryptography<37
 extendable-pydantic
 pydantic
-pyjq
+jq
 python-jose


### PR DESCRIPTION
replaced pyjq to jq due to the following reasons:
- Unmaintained
- no Python wheels, so requires to be build during install
- requires expensive dependecies to build
- increases the image size from 500MB to 2.5GB